### PR TITLE
Adding a note in README.md file about linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Great for prototyping, and fast development. Can always be moved to a separate t
 
 *Also works when generating inside an addon.*
 
+## Linting
+
+Note that the excellent [ember-template-lint](https://github.com/rwjblue/ember-template-lint)
+project is extremely helpful for finding lint errors in handlebars files, but will
+not examine template literals natively in `.js` files. However, it is possible to use
+`eslint` along with [this eslint plugin](https://github.com/psbanka/eslint-plugin-hbs)
+to provide linting for your handlebars template literals within your `.js` files.
+
 ## Contributing
 
 If you see any issues, please submit an Issue, or a Pull Request if you can.


### PR DESCRIPTION
Hello, we over at Fastly are trying to adopt this plugin, but were sad to see that we couldn't lint our templates any longer. We have gotten spoiled using [ember-template-lint](https://github.com/rwjblue/ember-template-lint) and many of our developers were unwilling to move forward with using this plugin if linting was going to be taken away.

So we developed an [eslint plugin](https://github.com/psbanka/eslint-plugin-hbs) which uses `ember-template-lint` under the hood to check any template-literals that contain handlebars syntax. This just adds a note to your `README.md` file so people understand that this is an option.